### PR TITLE
Cloudant sync updates

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -10,11 +10,14 @@ const winston = require('winston');
 module.exports = new (winston.Logger)({
 	transports: [
 		new (winston.transports.Console)({
-			level: process.env.COGNITIVE_LOG_LEVEL || 'error',
+			level: process.env.COGNITIVE_LOG_LEVEL || 'info',
 			silent: Boolean(process.env.SUPPRESS_ERRORS) || false,
 			prettyPrint: true,
 			colorize: true,
-			timestamp: true
+			timestamp: function(){
+				let d = new Date();
+				return '[' + d.toDateString() + ' ' + d.toTimeString() + ']';
+			}
 		})
 	]
 });

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -15,8 +15,7 @@ module.exports = new (winston.Logger)({
 			prettyPrint: true,
 			colorize: true,
 			timestamp: function(){
-				let d = new Date();
-				return '[' + d.toDateString() + ' ' + d.toTimeString() + ']';
+				return '[' + new Date().toDateString() + ' ' + new Date().toTimeString() + ']';
 			}
 		})
 	]

--- a/src/lib/nlcDb.js
+++ b/src/lib/nlcDb.js
@@ -9,8 +9,6 @@
 const path = require('path');
 const TAG = path.basename(__filename);
 const logger = require('./logger');
-const events = require('events');
-const eventEmitter = new events.EventEmitter();
 const env = require('./env');
 const HubotPouch = require('./hubotPouch');
 const pjson = require(path.resolve(process.cwd(), 'package.json'));
@@ -19,6 +17,9 @@ const classesDesignDoc = '_design/classes';
 const classesView = 'classes/byClass';
 const targetView = 'classes/byTarget';
 
+// TODO: Commenting because we don't currently use this, enable auto-training in the future.
+// const events = require('events');
+// const eventEmitter = new events.EventEmitter();
 
 const pouch = new Promise((resolve, reject) => {
 	try {
@@ -27,7 +28,8 @@ const pouch = new Promise((resolve, reject) => {
 
 		const syncFn = function(){
 			logger.info(`${TAG}: Starting sync of NLC training data with Cloudant.`);
-			// let update = false;  //TODO: Commenting because we don't currently use this, but this is a good possible enhancement.
+			// TODO: Commenting because we don't currently use this, but auto-training should be a future enhancement.
+			// let update = false;
 			db.sync(`https://${env.cloudantKey}:${env.cloudantPassword}@${env.cloudantEndpoint}/${env.cloudantDb}`,
 				{
 					include_docs: true,

--- a/src/lib/nlcDb.js
+++ b/src/lib/nlcDb.js
@@ -257,8 +257,6 @@ module.exports.post = function(classification, type, selectedClass) {
 		if (this.db){
 			return this.db.post(doc).then((result) => {
 				resolve(result);
-			}).catch((err) => {
-				reject(err);
 			});
 		}
 		else {
@@ -297,8 +295,6 @@ module.exports.info = function(opts){
 				if (opts && (opts.allDocs || opts.include_docs)){
 					return this.db.allDocs(opts).then((allDocs) => {
 						resolve(allDocs);
-					}).catch((err) => {
-						reject(err);
 					});
 				}
 				else {

--- a/src/lib/nlcDb.js
+++ b/src/lib/nlcDb.js
@@ -27,30 +27,25 @@ const pouch = new Promise((resolve, reject) => {
 
 		const syncFn = function(){
 			logger.info(`${TAG}: Starting sync of NLC training data with Cloudant.`);
-			let update = false;
+			// let update = false;  //TODO: Commenting because we don't currently use this, but this is a good possible enhancement.
 			db.sync(`https://${env.cloudantKey}:${env.cloudantPassword}@${env.cloudantEndpoint}/${env.cloudantDb}`,
 				{
 					include_docs: true,
 					filter: function(doc) {
 						// filter client side documents that we don't want synchronized
-						if (doc.storageType === 'private'){
-							return false;
-						}
-						else {
-							return true;
-						}
+						return doc.storageType !== 'private';
 					}
 				})
-				.on('change', function(change){
-					update = true;
-				})
+				// .on('change', function(change){
+				// 	update = true;
+				// })
 				.on('complete', function(info){
 					logger.info(`${TAG}: Completed sync of NLC training data with Cloudant.`);
 					logger.debug(`${TAG}: Cloudant sync results.`, info);
 
-					if (update){
-						eventEmitter.emit('nlc.retrain');
-					}
+					// if (update){
+					// 	eventEmitter.emit('nlc.retrain');
+					// }
 					setTimeout(syncFn, env.syncInterval);
 				})
 				.on('denied', function(err){


### PR DESCRIPTION
- Start sync on process startup. Resolves #43
- Add logging to sync.
- Update logger date format to match Hubot’s.
- Change default log level to info.
- Only auto-approve records of type===‘learned’
